### PR TITLE
Fix _id sync

### DIFF
--- a/Controller/Admin.php
+++ b/Controller/Admin.php
@@ -668,12 +668,18 @@ class Admin extends AuthController {
                   continue;
                 }
                 foreach ($entry[$field['name']] as $idx => $value) {
-                  if (isset($value['_id']) && isset($idsMapping[$value['_id']])) {
-                    $entry[$field['name']][$idx]['_id'] = $idsMapping[$value['_id']];
+                  if (is_array($value)) {
+                    if (isset($value['_id']) && isset($idsMapping[$value['_id']])) {
+                      $entry[$field['name']][$idx]['_id'] = $idsMapping[$value['_id']];
+                    }
+                  } else {
+                    if (isset($idsMapping[$value])) {
+                      $entry[$field['name']]['_id'] = $idsMapping[$value];
+                    }
                   }
                 }
               }
-              unset($entries);
+              unset($entry);
               break;
           }
         }

--- a/Controller/Admin.php
+++ b/Controller/Admin.php
@@ -663,20 +663,21 @@ class Admin extends AuthController {
           switch ($field['type']) {
             case 'multiplecollectionlink':
             case 'collectionlink':
-              foreach ($entries as $entry) {
+              foreach ($entries as &$entry) {
                 if (!isset($entry[$field['name']])) {
                   continue;
                 }
                 foreach ($entry[$field['name']] as $idx => $value) {
                   if (isset($value['_id']) && isset($idsMapping[$value['_id']])) {
                     $entry[$field['name']][$idx]['_id'] = $idsMapping[$value['_id']];
-                    $this->module('collections')->save($collection['name'], [$entry]);
                   }
                 }
               }
+              unset($entries);
               break;
           }
         }
+        $this->module('collections')->save($collection['name'], $entries);
       }
     }
   }


### PR DESCRIPTION
I had an issue with the synchronisation of _ids in collection links.
Some were not updated and it seems it was a dangling reference in a for loop since it was consistently the same ones every time.
This update fixes the dangling reference so the new _ids taken from the $idsMapping array are always applied without being lost in subsequent loops.

Not sure if this is related to [#3](https://github.com/pauloamgomes/BackupAndRestore/issues/3) since that seems to be more about them not restoring at all. However, I do not have that problem with the code as it is. My PR only fixes the dangler and it also leaves the save until even later than your suggested alternative to that PR and does it after the nested loops are all completed and so sends the full $entries array just once.

EDIT:

I've made a further change to allow for both single item and multiple item collection links. Now I think I know what [#3](https://github.com/pauloamgomes/BackupAndRestore/issues/3) was about. That user obviously had all their collection links set to multiple:false. With the code as it was, none would have been processed. The proposed change might have reversed the issue and processed all the single item collection links and none of the multiple item collection links. This update will process both.