### PR TITLE
Do not recover current user when _id has changed

### DIFF
--- a/Controller/Admin.php
+++ b/Controller/Admin.php
@@ -579,7 +579,7 @@ class Admin extends AuthController {
       }
 
       foreach ($data['accounts'] as $account) {
-        if ($account['user'] && $account['_id'] !== $current) {
+        if ($account['user'] && $account['_id'] !== $current && $account['name'] !== $this->user['name']) {
           if ($fullRestore || !$this->app->storage->findOne("cockpit/accounts", ["_id" => $account['_id']])) {
             $this->app->storage->insert("cockpit/accounts", $account);
           }


### PR DESCRIPTION
When restoring to a newly installed cockpit instance the _id of admin
will have changed. Extend the check to also require the saved users
name to not be the same as the current user.